### PR TITLE
feat: 🎸 implement inputProps and selectProps

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -34,6 +34,7 @@ Provides a simple input element, that allows users to enter their postcode and s
 ```jsx
 <PostcodeLookup.Input
   classNames={Object}
+  inputProps={Object}
   completions={Array}
   onChange={Function}
   onSubmit={Function}
@@ -41,16 +42,17 @@ Provides a simple input element, that allows users to enter their postcode and s
 />
 ```
 
-* `classNames`: A map of class names that will be used on the elements that are rendered.
-  * `input`: Map of classes that apply styles to the input element which the user enters their postcode into.
-    * `container`: Class names applied to the surrounding `<div>` element.
-    * `input`: Class names applied to the `<input>` element.
-    * `label`: Class names applied ot the `<label>` element.
-    * `button`: Class names applied to the `<button>` element.
-* `completions`: A list of address completions for the current value being entered into the postcode lookup field.
-* `onChange`: A function that accepts a string of the current value entered into the postcode lookup field.
-* `onSubmit`: A function that accepts a string of the value to use for the postcode lookup request.
-* `useAutocomplete`: True if completions should be provided, false if they are disabled.
+- `classNames`: A map of class names that will be used on the elements that are rendered.
+  - `input`: Map of classes that apply styles to the input element which the user enters their postcode into.
+    - `container`: Class names applied to the surrounding `<div>` element.
+    - `input`: Class names applied to the `<input>` element.
+    - `label`: Class names applied ot the `<label>` element.
+    - `button`: Class names applied to the `<button>` element.
+- `inputProps`: A map of props that are passed through to the `<input>` element.
+- `completions`: A list of address completions for the current value being entered into the postcode lookup field.
+- `onChange`: A function that accepts a string of the current value entered into the postcode lookup field.
+- `onSubmit`: A function that accepts a string of the value to use for the postcode lookup request.
+- `useAutocomplete`: True if completions should be provided, false if they are disabled.
 
 ### PostcodeLookup.Select
 
@@ -59,82 +61,78 @@ When a valid postcode has been entered and a lookup has been requested, this com
 ```jsx
 <PostcodeLookup.Select
   classNames={Object}
+  selectProps={Object}
   addresses={Array}
   onSelected={Function}
 />
 ```
 
-* `classNames`: A map of class names that will be used on the elements that are rendered.
-  * `select`: A map of classes that applies styles to the element that contains the list of matching addresses.
-    * `container `: Class names applied to the surrounding `<div>` element.
-    * `select`: Class names applied to the `<select>` element.
-    * `label`: Class names applied ot the `<label>` element.
-* `addresses`: An array of arrays that provide an ID and value for each matching address returnd from the postcode lookup request.
-* `onSelected`: A function that accepts the ID of an address that the user has chosen.
+- `classNames`: A map of class names that will be used on the elements that are rendered.
+  - `select`: A map of classes that applies styles to the element that contains the list of matching addresses.
+    - `container`: Class names applied to the surrounding `<div>` element.
+    - `select`: Class names applied to the `<select>` element.
+    - `label`: Class names applied ot the `<label>` element.
+- `selectProps`: A map of props that are passed through to the `<select>` element.
+- `addresses`: An array of arrays that provide an ID and value for each matching address returnd from the postcode lookup request.
+- `onSelected`: A function that accepts the ID of an address that the user has chosen.
 
 ### PostcodeLookup.Address
 
-Once a matching address has been selected by the user, this component will render any children passed to it. It uses the configured `addressSelectors` _(if any)_ to update the value of uncontrolled child input elements. 
+Once a matching address has been selected by the user, this component will render any children passed to it. It uses the configured `addressSelectors` _(if any)_ to update the value of uncontrolled child input elements.
 
 Otherwise, it will pass an `address` prop to a single child component allowing a custom element to update the value of any controlled inputs.
 
 This component allows you to configure and use a [custom address form component](/frameworks/react/integration).
 
 ```jsx
-<PostcodeLookup.Address
-  address={Object}
-  addressSelectors={Object}
->
+<PostcodeLookup.Address address={Object} addressSelectors={Object}>
   {children}
 </PostcodeLookup.Address>
 ```
 
-* `address`: An object that represents the address that has been selected by the user. This prop is provided by the connector function but can be provided manually for testing.
-* `addressSelectors`: A map of selectors that will be used to add values to the inputs inside an address form.
-  * `address`: Selector used to target the input element, defaults to `[data-address-line1]`.
-  * `locality`: Selector used to target the input element, defaults to `[data-address-locality]`.
-  * `region`: Selector used to target the input element, defaults to `[data-address-county]`.
-  * `postcode`: Selector used to target the input element, defaults to `[data-address-postcode]`.
+- `address`: An object that represents the address that has been selected by the user. This prop is provided by the connector function but can be provided manually for testing.
+- `addressSelectors`: A map of selectors that will be used to add values to the inputs inside an address form.
+  - `address`: Selector used to target the input element, defaults to `[data-address-line1]`.
+  - `locality`: Selector used to target the input element, defaults to `[data-address-locality]`.
+  - `region`: Selector used to target the input element, defaults to `[data-address-county]`.
+  - `postcode`: Selector used to target the input element, defaults to `[data-address-postcode]`.
 
 ### PostcodeLookup.AddressForm
 
 A component that provides an address form that renders the following input elements:
 
-* Address Line 1
-* Address Line 2
-* City/Locality
-* County/Region
-* Postcode
+- Address Line 1
+- Address Line 2
+- City/Locality
+- County/Region
+- Postcode
 
 **Note:** No styling is applied to any of the elements, so be sure to provide some of your own.
 
 ```jsx
-<PostcodeLookup.AddressForm
-  classNames={Object}
-  legend={String}
-/>
+<PostcodeLookup.AddressForm classNames={Object} legend={String} />
 ```
 
-* `classNames`: A map of class names that will be used on the elements that are rendered.
-  * `addressForm`: Provide a map of styles that are applied to the form elements rendered using the `<PostcodeLookup.AddressForm/>` component. If you use your own address form, this property is not used.
-    * `addressLine1`: A map of styles applied to the first line of the address form.
-      * `container`: Class names applied to the surrounding `<div>` element.
-      * `input` : Class names applied to the `<input>` element.
-      * `label`: Class names applied ot the `<label>` element.
-    * `addressLine2`: A map of styles applied to the second line of the address form.
-      * `container`: Class names applied to the surrounding `<div>` element.
-      * `input `: Class names applied to the `<input>` element.
-      * `label`: Class names applied ot the `<label>` element.
-    * `locality`: Map of styles that are applied to the city/locality input of the address form.
-      * `container`: Class names applied to the surrounding `<div>` element.
-      * `input `: Class names applied to the `<input>` element.
-      * `label`: Class names applied ot the `<label>` element.
-    * `county`: Map of styles that are applied to the county/region input of the address form.
-      * `container`: Class names applied to the surrounding `<div>` element.
-      * `input `: Class names applied to the `<input>` element.
-      * `label`: Class names applied ot the `<label>` element.
-    * `postcode`: Map of styles that are applied to the postcode input of the address form.
-      * `container`: Class names applied to the surrounding `<div>` element.
-      * `input `: Class names applied to the `<input>` element.
-      * `label`: Class names applied ot the `<label>` element.
-* `legend`: A string that will be rendered as part of the [legend element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/legend).
+- `classNames`: A map of class names that will be used on the elements that are rendered.
+  - `addressForm`: Provide a map of styles that are applied to the form elements rendered using the `<PostcodeLookup.AddressForm/>` component. If you use your own address form, this property is not used.
+    - `addressLine1`: A map of styles applied to the first line of the address form.
+      - `container`: Class names applied to the surrounding `<div>` element.
+      - `input` : Class names applied to the `<input>` element.
+      - `label`: Class names applied ot the `<label>` element.
+    - `addressLine2`: A map of styles applied to the second line of the address form.
+      - `container`: Class names applied to the surrounding `<div>` element.
+      - `input`: Class names applied to the `<input>` element.
+      - `label`: Class names applied ot the `<label>` element.
+    - `locality`: Map of styles that are applied to the city/locality input of the address form.
+      - `container`: Class names applied to the surrounding `<div>` element.
+      - `input`: Class names applied to the `<input>` element.
+      - `label`: Class names applied ot the `<label>` element.
+    - `county`: Map of styles that are applied to the county/region input of the address form.
+      - `container`: Class names applied to the surrounding `<div>` element.
+      - `input`: Class names applied to the `<input>` element.
+      - `label`: Class names applied ot the `<label>` element.
+    - `postcode`: Map of styles that are applied to the postcode input of the address form.
+      - `container`: Class names applied to the surrounding `<div>` element.
+      - `input`: Class names applied to the `<input>` element.
+      - `label`: Class names applied ot the `<label>` element.
+- `legend`: A string that will be rendered as part of the [legend element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/legend).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1981,6 +1981,12 @@
       "integrity": "sha512-1dVNHT76Uu5N3eJNTYcvxee+jzX4Z9lfciqRRHCU27ihbUcYi+iSc2iml5Ke1LXe1SyJCLA0+14Jh4tXJgOppA==",
       "dev": true
     },
+    "@hapi/formula": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/formula/-/formula-2.0.0.tgz",
+      "integrity": "sha512-V87P8fv7PI0LH7LiVi8Lkf3x+KCO7pQozXRssAHNXXL9L1K+uyu4XypLXwxqVDKgyQai6qj3/KteNlrqDx4W5A==",
+      "dev": true
+    },
     "@hapi/hoek": {
       "version": "8.5.1",
       "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-8.5.1.tgz",
@@ -1998,6 +2004,12 @@
         "@hapi/hoek": "8.x.x",
         "@hapi/topo": "3.x.x"
       }
+    },
+    "@hapi/pinpoint": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/pinpoint/-/pinpoint-2.0.0.tgz",
+      "integrity": "sha512-vzXR5MY7n4XeIvLpfl3HtE3coZYO4raKXW766R6DZw/6aLqR26iuZ109K7a0NtF2Db0jxqh7xz2AxkUwpUFybw==",
+      "dev": true
     },
     "@hapi/topo": {
       "version": "3.1.6",
@@ -4219,6 +4231,41 @@
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-3.5.5.tgz",
       "integrity": "sha512-5P0QZ6J5xGikH780pghEdbEKijCTrruK9KxtPZCFWUpef0f6GipO+xEZ5GKCb020mmqgbiNO6TcA55CriL784Q==",
       "dev": true
+    },
+    "axios": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
+      "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
+      "dev": true,
+      "requires": {
+        "follow-redirects": "1.5.10"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "follow-redirects": {
+          "version": "1.5.10",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+          "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+          "dev": true,
+          "requires": {
+            "debug": "=3.1.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
+      }
     },
     "axobject-query": {
       "version": "2.1.2",
@@ -8026,6 +8073,21 @@
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
       "dev": true
     },
+    "event-stream": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+      "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
+      "dev": true,
+      "requires": {
+        "duplexer": "~0.1.1",
+        "from": "~0",
+        "map-stream": "~0.1.0",
+        "pause-stream": "0.0.11",
+        "split": "0.3",
+        "stream-combiner": "~0.0.4",
+        "through": "~2.3.1"
+      }
+    },
     "eventemitter2": {
       "version": "6.4.3",
       "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.3.tgz",
@@ -8778,6 +8840,12 @@
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
+      "dev": true
+    },
+    "from": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
+      "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=",
       "dev": true
     },
     "from2": {
@@ -9667,6 +9735,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
       "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
+      "dev": true
+    },
+    "human-signals": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
+      "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
       "dev": true
     },
     "iconv-lite": {
@@ -11490,6 +11564,45 @@
         }
       }
     },
+    "joi": {
+      "version": "17.2.0",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.2.0.tgz",
+      "integrity": "sha512-9ZC8pMSitNlenuwKARENBGVvvGYHNlwWe5rexo2WxyogaxCB5dNHAgFA1BJQ6nsJrt/jz1p5vSqDT6W6kciDDw==",
+      "dev": true,
+      "requires": {
+        "@hapi/address": "^4.1.0",
+        "@hapi/formula": "^2.0.0",
+        "@hapi/hoek": "^9.0.0",
+        "@hapi/pinpoint": "^2.0.0",
+        "@hapi/topo": "^5.0.0"
+      },
+      "dependencies": {
+        "@hapi/address": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/@hapi/address/-/address-4.1.0.tgz",
+          "integrity": "sha512-SkszZf13HVgGmChdHo/PxchnSaCJ6cetVqLzyciudzZRT0jcOouIF/Q93mgjw8cce+D+4F4C1Z/WrfFN+O3VHQ==",
+          "dev": true,
+          "requires": {
+            "@hapi/hoek": "^9.0.0"
+          }
+        },
+        "@hapi/hoek": {
+          "version": "9.0.4",
+          "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.0.4.tgz",
+          "integrity": "sha512-EwaJS7RjoXUZ2cXXKZZxZqieGtc7RbvQhUy8FwDoMQtxWVi14tFjeFCYPZAM1mBCpOpiBpyaZbb9NeHc7eGKgw==",
+          "dev": true
+        },
+        "@hapi/topo": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.0.0.tgz",
+          "integrity": "sha512-tFJlT47db0kMqVm3H4nQYgn6Pwg10GTZHb1pwmSiv1K4ks6drQOtfEF5ZnPjkvC+y4/bUPHK+bc87QvLcL+WMw==",
+          "dev": true,
+          "requires": {
+            "@hapi/hoek": "^9.0.0"
+          }
+        }
+      }
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -12300,6 +12413,12 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.1.0.tgz",
       "integrity": "sha512-glc9y00wgtwcDmp7GaE/0b0OnxpNJsVf3ael/An6Fe2Q51LLwN1er6sdomLRzz5h0+yMpiYLhWYF5R7HeqVd4g==",
+      "dev": true
+    },
+    "map-stream": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
+      "integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=",
       "dev": true
     },
     "map-visit": {
@@ -13719,6 +13838,15 @@
         "pify": "^3.0.0"
       }
     },
+    "pause-stream": {
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+      "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
+      "dev": true,
+      "requires": {
+        "through": "~2.3"
+      }
+    },
     "pbkdf2": {
       "version": "3.0.17",
       "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.17.tgz",
@@ -15049,6 +15177,15 @@
       "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
       "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
       "dev": true
+    },
+    "ps-tree": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/ps-tree/-/ps-tree-1.2.0.tgz",
+      "integrity": "sha512-0VnamPPYHl4uaU/nSFeZZpR21QAWRz+sRv4iW9+v/GS/J5U5iZB5BNN6J0RMoOvdx2gWM2+ZFMIm58q24e4UYA==",
+      "dev": true,
+      "requires": {
+        "event-stream": "=3.3.4"
+      }
     },
     "psl": {
       "version": "1.8.0",
@@ -17395,6 +17532,15 @@
         "wbuf": "^1.7.3"
       }
     },
+    "split": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
+      "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
+      "dev": true,
+      "requires": {
+        "through": "2"
+      }
+    },
     "split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -17457,6 +17603,112 @@
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.2.tgz",
       "integrity": "sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA==",
       "dev": true
+    },
+    "start-server-and-test": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/start-server-and-test/-/start-server-and-test-1.11.3.tgz",
+      "integrity": "sha512-7r2lvcnJPECSG+ydMzk1wLt3MdzsHnYj+kXgKyzbvTXul5XYEmYJJ3K7YUGNgo5w/vnZb8L/AZMyg1C17qBdzg==",
+      "dev": true,
+      "requires": {
+        "bluebird": "3.7.2",
+        "check-more-types": "2.24.0",
+        "debug": "4.1.1",
+        "execa": "3.4.0",
+        "lazy-ass": "1.6.0",
+        "ps-tree": "1.2.0",
+        "wait-on": "5.2.0"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+          "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
+          }
+        },
+        "execa": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-3.4.0.tgz",
+          "integrity": "sha512-r9vdGQk4bmCuK1yKQu1KTwcT2zwfWdbdaXfCtAh+5nU/4fSX+JAb7vZGvI5naJrQlvONrEB20jeruESI69530g==",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^7.0.0",
+            "get-stream": "^5.0.0",
+            "human-signals": "^1.1.1",
+            "is-stream": "^2.0.0",
+            "merge-stream": "^2.0.0",
+            "npm-run-path": "^4.0.0",
+            "onetime": "^5.1.0",
+            "p-finally": "^2.0.0",
+            "signal-exit": "^3.0.2",
+            "strip-final-newline": "^2.0.0"
+          }
+        },
+        "get-stream": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
+          "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        },
+        "is-stream": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+          "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
+          "dev": true
+        },
+        "npm-run-path": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+          "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.0.0"
+          }
+        },
+        "p-finally": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-2.0.1.tgz",
+          "integrity": "sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw==",
+          "dev": true
+        },
+        "path-key": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+          "dev": true
+        },
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+          "dev": true
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
     },
     "static-extend": {
       "version": "0.1.2",
@@ -17525,6 +17777,15 @@
             "safe-buffer": "~5.1.0"
           }
         }
+      }
+    },
+    "stream-combiner": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
+      "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
+      "dev": true,
+      "requires": {
+        "duplexer": "~0.1.1"
       }
     },
     "stream-each": {
@@ -17766,6 +18027,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+      "dev": true
+    },
+    "strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
       "dev": true
     },
     "strip-indent": {
@@ -18691,6 +18958,19 @@
         "domexception": "^1.0.1",
         "webidl-conversions": "^4.0.2",
         "xml-name-validator": "^3.0.0"
+      }
+    },
+    "wait-on": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-5.2.0.tgz",
+      "integrity": "sha512-U1D9PBgGw2XFc6iZqn45VBubw02VsLwnZWteQ1au4hUVHasTZuFSKRzlTB2dqgLhji16YVI8fgpEpwUdCr8B6g==",
+      "dev": true,
+      "requires": {
+        "axios": "^0.19.2",
+        "joi": "^17.1.1",
+        "lodash": "^4.17.19",
+        "minimist": "^1.2.5",
+        "rxjs": "^6.5.5"
       }
     },
     "walker": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,8 @@
     "format": "prettier --ignore-path .gitignore --write \"**/*.+(js|jsx|json|yml|yaml|css|md|vue)\"",
     "pretest": "npm run lint",
     "cypress": "cypress run --headless --browser chrome",
+    "cypress:open": "cypress open --browser chrome",
+    "open": "start-server-and-test start http://localhost:3000 cypress:open",
     "build": "rm -rf dist && NODE_ENV=production babel src/lib --out-dir dist --copy-files --ignore test.js",
     "postbuild": "npm run size-limit",
     "size-limit": "size-limit",
@@ -85,6 +87,7 @@
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-scripts": "3.4.1",
-    "size-limit": "^4.4.5"
+    "size-limit": "^4.4.5",
+    "start-server-and-test": "^1.11.3"
   }
 }

--- a/src/index.integration.js
+++ b/src/index.integration.js
@@ -10,6 +10,15 @@ describe('<PostcodeLookup />', () => {
       .as('fixture');
   });
 
+  describe('the rendered postcode form', () => {
+    it('renders a placeholder', () => {
+      cy.get('.test-input-input').as('input');
+      cy.get('@input')
+        .invoke('attr', 'placeholder')
+        .should('eq', 'Enter a postcode');
+    });
+  });
+
   describe('when a postcode is entered and the button is clicked', () => {
     it('retrieves and fills a matching address', () => {
       cy.get('.test-input-input').as('input');

--- a/src/index.js
+++ b/src/index.js
@@ -63,7 +63,9 @@ const App = () => (
       <PostcodeLookup {...postcodeLookupProps}>
         <fieldset>
           <legend>Find your address</legend>
-          <PostcodeLookup.Input />
+          <PostcodeLookup.Input
+            inputProps={{ placeholder: 'Enter a postcode' }}
+          />
           <PostcodeLookup.Select />
         </fieldset>
         <PostcodeLookup.Address>

--- a/src/lib/components/Input.jsx
+++ b/src/lib/components/Input.jsx
@@ -9,6 +9,7 @@ const Input = ({
   completions,
   onSubmit,
   onChange,
+  inputProps,
   useAutocomplete,
 }) => {
   const inputRef = useRef();
@@ -43,6 +44,7 @@ const Input = ({
         onKeyUp={handleKeyUp}
         label="Postcode Lookup"
         name="postcode-lookup"
+        {...inputProps}
       >
         <button
           className={inputClasses.button}
@@ -68,6 +70,7 @@ Input.propTypes = {
   completions: PropTypes.array,
   onChange: PropTypes.func.isRequired,
   onSubmit: PropTypes.func.isRequired,
+  inputProps: PropTypes.object,
   classNames: PropTypes.object,
 };
 
@@ -75,6 +78,7 @@ Input.defaultProps = {
   useAutocomplete: true,
   completions: [],
   classNames: {},
+  inputProps: {},
 };
 
 export default Input;

--- a/src/lib/components/Input.test.jsx
+++ b/src/lib/components/Input.test.jsx
@@ -14,15 +14,31 @@ describe('<Input />', () => {
 
   let onSubmit;
 
+  let textInputProps;
+
   beforeEach(() => {
     inputProps = {};
     onChange = jest.fn();
     onSubmit = jest.fn();
+    textInputProps = {
+      placeholder: 'enter a postcode',
+    };
   });
 
   beforeEach(() => {
+    inputProps.inputProps = textInputProps;
     inputProps.onChange = onChange;
     inputProps.onSubmit = onSubmit;
+  });
+
+  describe('input props are passed through to the <input/> component', () => {
+    it('renders inputProps', () => {
+      const { container } = setup(inputProps);
+      const input = container.querySelector('input[type=text]');
+      expect(input.getAttribute('placeholder')).toEqual(
+        textInputProps.placeholder
+      );
+    });
   });
 
   describe('when the button is clicked', () => {

--- a/src/lib/components/Select.jsx
+++ b/src/lib/components/Select.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const Select = React.forwardRef(
-  ({ classNames, addresses, onSelected }, ref) => {
+  ({ classNames, addresses, onSelected, selectProps }, ref) => {
     const handleChange = (e) => onSelected(e.target.value);
 
     if (!addresses || addresses.length === 0) {
@@ -26,6 +26,7 @@ const Select = React.forwardRef(
           defaultValue="select"
           ref={ref}
           onChange={handleChange}
+          {...selectProps}
         >
           <option value="select" disabled>
             Choose an address...
@@ -46,11 +47,13 @@ Select.displayName = 'PostcodeLookup.Select';
 Select.propTypes = {
   addresses: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.string)),
   onSelected: PropTypes.func.isRequired,
+  selectProps: PropTypes.object,
   classNames: PropTypes.object,
 };
 
 Select.defaultProps = {
   addresses: [],
+  selectProps: {},
   classNames: {},
 };
 

--- a/src/lib/components/Select.test.jsx
+++ b/src/lib/components/Select.test.jsx
@@ -10,11 +10,17 @@ const setup = (props) => {
 describe('<Select/>', () => {
   let selectProps;
 
+  let selectInputProps;
+
   let onSelected;
 
   beforeEach(() => {
+    selectInputProps = {
+      'data-test': 'foobar',
+    };
     onSelected = jest.fn();
     selectProps = {
+      selectProps: selectInputProps,
       onSelected,
     };
   });
@@ -34,6 +40,14 @@ describe('<Select/>', () => {
 
     beforeEach(() => {
       selectProps.addresses = addresses;
+    });
+
+    it('renders select props passed through to the field', () => {
+      const { container } = setup(selectProps);
+      const select = container.querySelector('select');
+      expect(select.getAttribute('data-test')).toEqual(
+        selectInputProps['data-test']
+      );
     });
 
     it('renders a select element with the correct options', () => {


### PR DESCRIPTION
The `<PostcodeLookup.Input/>` and `<PostcodeLookup.Select/>` components now accept `inputProps={}` and `selectProps={}` respectively. When used, these props will be passed through to the rendered `<input/>` and `<select/>` form fields.

✅ Closes: #76